### PR TITLE
Correct case of filename in #include directive

### DIFF
--- a/src/TTN_M5Stack.h
+++ b/src/TTN_M5Stack.h
@@ -4,7 +4,7 @@
 #define _TTN_M5STACK_h
 
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "arduino.h"
+#include "Arduino.h"
 #else
 #include "WProgram.h"
 #endif


### PR DESCRIPTION
Incorrect capitalization of Arduino.h causes compilation to fail on filename case-sensitive operating systems like Linux.